### PR TITLE
fix: improve typing for Dict.entries

### DIFF
--- a/src/Dict.ts
+++ b/src/Dict.ts
@@ -1,7 +1,9 @@
 export function entries<T>(value: T) {
-  return Object.entries(value) as {
-    [K in keyof T]: K extends string ? [K, T[K]] : never;
-  }[keyof T][];
+  return Object.entries(value) as NonNullable<
+    {
+      [K in keyof T]: K extends string ? [K, T[K]] : never;
+    }[keyof T]
+  >[];
 }
 
 export function keys<T>(value: T) {


### PR DESCRIPTION
Hello 👋 

I'm working on a project where we have this kind of code 
```
interface Foo {
  optionalField?: string;
}

const a: Foo = {
  optionalField: "",
};
const result = entries(a);
```

because of the optional field, the type of `result` is `["optionalField", string | undefined] | undefined`. It means that TS would consider the entry as potentially undefined, which can't actually happen.

This PR aims to fix this, so that the type becomes `["optionalField", string | undefined]` :)
