### PR TITLE
Reexport Array statics that can be shadowed

### DIFF
--- a/src/Array.ts
+++ b/src/Array.ts
@@ -1,5 +1,11 @@
 import { Option } from "./Option";
 
+export const from = Array.from;
+
+export const of = Array.of;
+
+export const isArray = Array.isArray;
+
 export const keepMap = <A, B>(
   array: Array<A>,
   func: (item: A) => NonNullable<B> | undefined | null,

--- a/test/Array.test.ts
+++ b/test/Array.test.ts
@@ -1,5 +1,13 @@
 import { expect, test } from "vitest";
-import { binarySearchBy, getBy, getIndexBy, keepMap } from "../src/Array";
+import {
+  binarySearchBy,
+  from,
+  getBy,
+  getIndexBy,
+  isArray,
+  keepMap,
+  of,
+} from "../src/Array";
 import { Option } from "../src/Option";
 
 test("Array.keepMap", () => {
@@ -48,4 +56,13 @@ test("Array.binarySearchBy", () => {
   expect(binarySearchBy([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 5)).toEqual(4);
   expect(binarySearchBy([1, 2, 3, 4, 6, 7, 8, 9, 10], 5)).toEqual(4);
   expect(binarySearchBy([], 2)).toEqual(-1);
+});
+
+test("Array.of", () => {
+  expect(of(1, 2, 3)).toEqual([1, 2, 3]);
+
+  expect(from({ length: 3 }, (_, index) => index)).toEqual([0, 1, 2]);
+
+  expect(isArray([])).toEqual(true);
+  expect(isArray({ length: 0 })).toEqual(false);
 });


### PR DESCRIPTION
When doing:

```ts
import {Array} from "@swan-io/boxed";
```

and needing `Array.from` or `Array.isArray`, you'll need to alias `Array` (which isn't really practical). This PR adds the 3 useful static methods from the `Array` constructor.

The `Array` constructor doesn't seem particularly useful to bring here.
