### PR TITLE
Explicitly set publishConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "utility",
     "utilities"
   ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "prettier": {
     "trailingComma": "all"
   },


### PR DESCRIPTION
Set `publishConfig` in `package.json`:

- Because sometimes we forget adding the `--access public` option
- To fix conflicts with private registries.