### PR TITLE
Fix wrong return type of `Result.map` in documentation

### DIFF
--- a/docs/docs/result.md
+++ b/docs/docs/result.md
@@ -51,7 +51,7 @@ The result type provides a few manipulation functions:
 
 ## .map(f)
 
-If the result is `Ok(value)` returns `Ok(f(value))`, otherwise returns `None`.
+If the result is `Ok(value)` returns `Ok(f(value))`, otherwise returns `Error(error)`.
 
 ```ts
 Result.Ok(2).map((x) => x * 2); // Result.Ok(4)


### PR DESCRIPTION
The documentation previously stated that `Result.map(f)` returns `None` in case the initial result was `Result.Error`. This probably was erroneously copy&pasted from the documentation for `Option`.