### PR TITLE
Add `or` and `orElse` method to Option

### DIFF
--- a/docs/docs/option.md
+++ b/docs/docs/option.md
@@ -58,6 +58,38 @@ Option.Some(2).flatMap((x) => {
 });
 ```
 
+## .or(optionB)
+
+If the option is `None` returns `optionB`, otherwise returns the option.
+
+If you want to have a lazy verion of this function, use `.orElse(f)`.
+
+```ts
+Option.None<number>().or(Option.Some(2));
+```
+
+## .orElse(f)
+
+If the option is `None` returns `f()`, otherwise returns the option.
+
+```ts
+Option.None<number>().orElse(() => Option.Some(2));
+```
+
+## .flatMap(f)
+
+If the option is `Some(value)` returns `f(value)`, otherwise returns `None`.
+
+```ts
+Option.Some(2).flatMap((x) => {
+  if (x > 1) {
+    return Option.None();
+  } else {
+    return Option.Some(2);
+  }
+});
+```
+
 ## .getWithDefault(defaultValue)
 
 If the option is `Some(value)` returns `value`, otherwise returns `defaultValue`.

--- a/docs/docs/option.md
+++ b/docs/docs/option.md
@@ -62,7 +62,7 @@ Option.Some(2).flatMap((x) => {
 
 If the option is `None` returns `optionB`, otherwise returns the option.
 
-If you want to have a lazy verion of this function, use `.orElse(f)`.
+If you want to have a lazy version of this function, use `.orElse(f)`.
 
 ```ts
 Option.None<number>().or(Option.Some(2));

--- a/docs/docs/option.md
+++ b/docs/docs/option.md
@@ -65,7 +65,8 @@ If the option is `None` returns `optionB`, otherwise returns the option.
 If you want to have a lazy version of this function, use `.orElse(f)`.
 
 ```ts
-Option.None<number>().or(Option.Some(2));
+Option.None<number>().or(Option.Some(2)); // Option.Some(2)
+Option.Some(1).or(Option.Some(2)); // Option.Some(1)
 ```
 
 ## .orElse(f)
@@ -73,7 +74,8 @@ Option.None<number>().or(Option.Some(2));
 If the option is `None` returns `f()`, otherwise returns the option.
 
 ```ts
-Option.None<number>().orElse(() => Option.Some(2));
+Option.None<number>().orElse(() => Option.Some(2));// Option.Some(2)
+Option.Some(1).or(() => Option.Some(2)); // Option.Some(1)
 ```
 
 ## .flatMap(f)

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -24,6 +24,20 @@ class OptionClass<Value> {
       return this as unknown as Option<ReturnValue>;
     }
   }
+  or(optionB: Option<Value>): Option<Value> {
+    if(this.tag === "None"){
+      return optionB;
+    } else {
+      return this as Option<Value>;
+    }
+  }
+  orElse(f: () => Option<Value>): Option<Value> {
+    if(this.tag === "None"){
+      return f();
+    } else {
+      return this as Option<Value>;
+    }
+  }
   getWithDefault(defaultValue: Value): Value {
     if (this.tag === "Some") {
       return this.value as Value;

--- a/test/Option.test.ts
+++ b/test/Option.test.ts
@@ -24,6 +24,26 @@ test("Option.flatMap", () => {
   expect(Option.Some(1).flatMap((x) => Option.None())).toEqual(Option.None());
 });
 
+test("Option.or", () => {
+  expect(Option.Some(1).or(Option.Some(3))).toEqual(
+    Option.Some(1),
+  );
+  expect(Option.None<number>().or(Option.Some(3))).toEqual(
+    Option.Some(3),
+  );
+  expect(Option.None<number>().or(Option.None<number>())).toEqual(Option.None());
+});
+
+test("Option.orElse", () => {
+  expect(Option.Some(1).orElse(() => Option.Some(3))).toEqual(
+    Option.Some(1),
+  );
+  expect(Option.None<number>().orElse(() => Option.Some(3))).toEqual(
+    Option.Some(3),
+  );
+  expect(Option.None<number>().orElse(() => Option.None<number>())).toEqual(Option.None());
+});
+
 test("Option.getWithDefault", () => {
   expect(Option.Some(1).getWithDefault(0)).toEqual(1);
   expect(Option.None<number>().getWithDefault(0)).toEqual(0);


### PR DESCRIPTION
Hello,

I've made this little change to add `or` and `orElse` functions to Option type.

The goal is to have a function which will update the value only if we didn't have it before.

The `orElse` function is the lazy version of `or`.

Feel free to comment it.

Thank you.

Inspired by: [Rust: Option](https://doc.rust-lang.org/std/option/enum.Option.html)