### PR TITLE
Aggregate error types with union.

### DIFF
--- a/src/Result.ts
+++ b/src/Result.ts
@@ -17,13 +17,13 @@ class ResultClass<Ok, Error> {
       return this as unknown as Result<ReturnValue, Error>;
     }
   }
-  flatMap<ReturnValue>(
-    f: (value: Ok) => Result<ReturnValue, Error>,
-  ): Result<ReturnValue, Error> {
+  flatMap<ReturnValue, ResultError = Error>(
+    f: (value: Ok) => Result<ReturnValue, ResultError | Error>,
+  ): Result<ReturnValue, ResultError | Error> {
     if (this.tag === "Ok") {
       return f(this.value as Ok);
     } else {
-      return this as unknown as Result<ReturnValue, Error>;
+      return this as unknown as Result<ReturnValue, ResultError | Error>;
     }
   }
   getWithDefault(defaultValue: Ok): Ok {

--- a/test/Result.test.ts
+++ b/test/Result.test.ts
@@ -17,12 +17,21 @@ test("Result.map", () => {
   );
 });
 
+type A = 1;
+type B = 2;
+
 test("Result.flatMap", () => {
   expect(Result.Ok(1).flatMap((x) => Result.Ok(x * 2))).toEqual(Result.Ok(2));
   expect(
     Result.Error<number, number>(1).flatMap((x) => Result.Ok(x * 2)),
   ).toEqual(Result.Error(1));
   expect(Result.Ok(1).flatMap((x) => Result.Error(1))).toEqual(Result.Error(1));
+  const resultA: Result<number, A> = Result.Ok(1);
+  const resultB: Result<number, B> = Result.Error(2);
+  const resultC = resultA.flatMap((item) => {
+    return resultB;
+  });
+  expect(resultC).toEqual(Result.Error(2));
 });
 
 test("Result.getWithDefault", () => {


### PR DESCRIPTION
This isn't totally in line with Hindley–Milner type system, but neither
is TypeScript. The idea here is to concatenate the error types when
chaining Result with `flatMap`.

The typing still checks out for the case where you don't alter the error
type.

The DX improvement here is that it enables the type system to ensure
exhausitivity without having to annotate the call-site.
