### PR TITLE
Fix typing for `get` and `getError` methods

### DIFF
--- a/src/Result.ts
+++ b/src/Result.ts
@@ -268,14 +268,14 @@ export class Result<Ok, Error> {
   /**
    * Returns the ok value. Use within `if (result.isOk()) { ... }`
    */
-  get(this: Result<Ok, Error> & { value: { tag: "Ok"; value: Ok } }): Ok {
+  get(this: Result<Ok, Error> & { tag: "Ok"; value: { value: Ok } }): Ok {
     return this.value.value;
   }
   /**
    * Returns the error value. Use within `if (result.isError()) { ... }`
    */
   getError(
-    this: Result<Ok, Error> & { value: { tag: "Error"; value: Error } },
+    this: Result<Ok, Error> & { tag: "Error"; value: { value: Error } },
   ): Error {
     return this.value.value;
   }

--- a/test/Result.test.ts
+++ b/test/Result.test.ts
@@ -67,6 +67,20 @@ test("Result.getWithDefault", () => {
   expect(Result.Error<number, number>(1).getWithDefault(0)).toEqual(0);
 });
 
+test("Result.get", () => {
+  const result: Result<number, unknown> = Result.Ok(1);
+  if (result.isOk()) {
+    expect(result.get()).toEqual(1);
+  }
+});
+
+test("Result.getError", () => {
+  const result: Result<unknown, number> = Result.Error(1);
+  if (result.isError()) {
+    expect(result.getError()).toEqual(1);
+  }
+});
+
 test("Result.match", () => {
   Result.Error<number, number>(1).match({
     Error: (value) => expect(value).toBe(1),


### PR DESCRIPTION
Fixes the bug I encountered and described in #12. 
Feel free to comment if I misunderstood something or fixed it the wrong way.