### PR TITLE
Fix wording in the Result docs

### DIFF
--- a/docs/docs/result.md
+++ b/docs/docs/result.md
@@ -104,7 +104,7 @@ Result.Error(2).getWithDefault(1); // 1
 
 ## .isOk()
 
-Type guard. Checks if the option is `Ok(value)`
+Type guard. Checks if the result is `Ok(value)`
 
 ```ts
 Result.Ok(2).isOk(); // true
@@ -117,7 +117,7 @@ if (result.isOk()) {
 
 ## .isError()
 
-Type guard. Checks if the option is `None`
+Type guard. Checks if the result is `Error(error)`
 
 ```ts
 Result.Ok(2).isError(); // false


### PR DESCRIPTION
This PR fixes a few wordings in the `Result` docs that were probably leftovers from a copy of the `Option` docs.