### PR TITLE
Dict utility: Define T as Record<string | number | symbol, unknown>

### DIFF
--- a/src/Dict.ts
+++ b/src/Dict.ts
@@ -1,4 +1,6 @@
-export function entries<T>(value: T) {
+export function entries<T extends Record<string | number | symbol, unknown>>(
+  value: T,
+) {
   return Object.entries(value) as NonNullable<
     {
       [K in keyof T]: K extends string ? [K, T[K]] : never;
@@ -6,7 +8,9 @@ export function entries<T>(value: T) {
   >[];
 }
 
-export function keys<T>(value: T) {
+export function keys<T extends Record<string | number | symbol, unknown>>(
+  value: T,
+) {
   return Object.keys(value) as NonNullable<
     {
       [K in keyof T]: K extends string ? K : never;
@@ -14,7 +18,9 @@ export function keys<T>(value: T) {
   >[];
 }
 
-export function values<T>(value: T) {
+export function values<T extends Record<string | number | symbol, unknown>>(
+  value: T,
+) {
   return Object.values(value) as {
     [K in keyof T]: K extends string ? T[K] : never;
   }[keyof T][];


### PR DESCRIPTION
This fixed a noverload error I get in Visual Studio Code:

```typescript
  No overload matches this call.
   Overload 1 of 2, '(o: { [s: string]: T[string]; } | ArrayLike<T[string]>): [string, T[string]][]', gave the following error.
     Argument of type 'T' is not assignable to parameter of type '{ [s: string]: T[string]; } | ArrayLike<T[string]>'.
       Type 'T' is not assignable to type 'ArrayLike<T[string]>'.
   Overload 2 of 2, '(o: {}): [string, any][]', gave the following error.
     Argument of type 'T' is not assignable to parameter of type '{}'.
```

The package builds without  problem even without this fix, but the editor complains if T is not explicitly an Object.