### PR TITLE
Add convenience methods

### DIFF
--- a/docs/docs/array.md
+++ b/docs/docs/array.md
@@ -51,6 +51,28 @@ Returns the index of the item if there's an exact match, return the index of the
 const index = Array.binarySearchBy(array, "my value");
 ```
 
+## Array.zip(arrayA, arrayB)
+
+Create an array of pairs from two arrays.
+
+```ts
+Array.zip([1, 2, 3], ["one", "two", "three"]);
+// [[1, "one"], [2, "two"], [3, "three"]]
+```
+
+## Array.unzip(arrayOfPairs)
+
+Turns an array of pairs into two arrays.
+
+```ts
+Array.zip([
+  [1, "one"],
+  [2, "two"],
+  [3, "three"],
+]);
+// [[1, 2, 3], ["one", "two", "three"]]
+```
+
 ## Array.from(arrayLike)
 
 [Array.from](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Array/from), reexported for convenience when Boxed `Array` shadows the `Array` constructor in scope.

--- a/docs/docs/async-data.md
+++ b/docs/docs/async-data.md
@@ -178,6 +178,37 @@ AsyncData.all([Result.Loading(), AsyncData.Done(2), AsyncData.Done(3)]);
 // Result.Loading()
 ```
 
+## AsyncData.allFromDict(asyncDatas)
+
+```ts
+allFromDict(asyncDatas: Dict<AsyncData<A>>): AsyncData<Dict<A>>
+```
+
+Turns a "dict of asyncDatas of value" into a "asyncData of dict of value".
+
+```ts
+AsyncData.allFromDict({
+  a: AsyncData.Done(1),
+  b: AsyncData.Done(2),
+  c: AsyncData.Done(3),
+});
+// Done({a: 1, b: 2, c: 3})
+
+AsyncData.allFromDict({
+  a: Result.NotAsked(),
+  b: AsyncData.Done(2),
+  c: AsyncData.Done(3),
+});
+// Result.NotAsked()
+
+AsyncData.allFromDict({
+  a: Result.Loading(),
+  b: AsyncData.Done(2),
+  c: AsyncData.Done(3),
+});
+// Result.Loading()
+```
+
 ## TS Pattern interop
 
 ```ts

--- a/docs/docs/future.md
+++ b/docs/docs/future.md
@@ -151,6 +151,23 @@ Future.all([Future.value(1), Future.value(2), Future.value(3)]);
 // Future<[1, 2, 3]>
 ```
 
+## Future.allFromDict(futures)
+
+```ts
+allFromDict(futures: Dict<Future<A>>): Future<Dict<A>>
+```
+
+Turns a "dict of futures of values" into a "future of dict of value".
+
+```ts
+Future.allFromDict({
+  a: Future.value(1),
+  b: Future.value(2),
+  c: Future.value(3),
+});
+// Future<{a: 1, b: 2, c: 3}>
+```
+
 ## Interop
 
 ### Future.fromPromise(promise)

--- a/docs/docs/option.md
+++ b/docs/docs/option.md
@@ -199,6 +199,22 @@ Option.all([Option.None(), Option.Some(2), Option.Some(3)]);
 // None
 ```
 
+## Option.allFromDict(options)
+
+```ts
+allFromDict(options: Dict<Option<A>>): Option<Dict<A>>
+```
+
+Turns a "dict of options of value" into a "option of dict of value".
+
+```ts
+Option.allFromDict({ a: Option.Some(1), b: Option.Some(2), c: Option.Some(3) });
+// Some({a: 1, b: 2, c: 3})
+
+Option.allFromDict({ a: Option.None(), b: Option.Some(2), c: Option.Some(3) });
+// None
+```
+
 ## TS Pattern interop
 
 ```ts

--- a/docs/docs/result.md
+++ b/docs/docs/result.md
@@ -252,6 +252,26 @@ Result.all([Result.Error("error"), Result.Ok(2), Result.Ok(3)]);
 // Error("error")
 ```
 
+## Result.allFromDict(results)
+
+```ts
+allFromDict(options: Dict<Result<A, E>>): Result<Dict<A>, E>
+```
+
+Turns a "dict of results of value" into a "result of dict of value".
+
+```ts
+Result.allFromDict({ a: Result.Ok(1), b: Result.Ok(2), c: Result.Ok(3) });
+// Ok({a: 1, b: 2, c: 3})
+
+Result.allFromDict({
+  a: Result.Error("error"),
+  b: Result.Ok(2),
+  c: Result.Ok(3),
+});
+// Error("error")
+```
+
 ## Interop
 
 ### Result.fromExecution(() => value)

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -85,3 +85,5 @@ export const binarySearchBy = <A>(
     }
   }
 };
+
+export { unzip, zip } from "./ZipUnzip";

--- a/src/AsyncData.ts
+++ b/src/AsyncData.ts
@@ -1,4 +1,6 @@
+import { keys, values } from "./Dict";
 import { Option } from "./OptionResult";
+import { zip } from "./ZipUnzip";
 
 export class AsyncData<A> {
   /**
@@ -56,6 +58,20 @@ export class AsyncData<A> {
       });
       index++;
     }
+  };
+
+  /**
+   * Turns an dict of asyncData into a asyncData of dict
+   */
+  static allFromDict = <Dict extends Record<string, AsyncData<any>>>(
+    dict: Dict,
+  ): AsyncData<{
+    -readonly [P in keyof Dict]: Dict[P] extends AsyncData<infer T> ? T : never;
+  }> => {
+    const dictKeys = keys(dict);
+    return AsyncData.all(values(dict)).map((values) =>
+      Object.fromEntries(zip(dictKeys, values)),
+    );
   };
 
   static equals = <A>(

--- a/src/Future.ts
+++ b/src/Future.ts
@@ -1,4 +1,6 @@
+import { keys, values } from "./Dict";
 import { Result } from "./OptionResult";
+import { zip } from "./ZipUnzip";
 
 type PendingPayload<A> = {
   resolveCallbacks?: Array<(value: A) => void>;
@@ -90,6 +92,20 @@ export class Future<A> {
       }, propagateCancel);
       index++;
     }
+  };
+
+  /**
+   * Turns an dict of futures into a future of dict
+   */
+  static allFromDict = <Dict extends Record<string, Future<any>>>(
+    dict: Dict,
+  ): Future<{
+    -readonly [P in keyof Dict]: Dict[P] extends Future<infer T> ? T : never;
+  }> => {
+    const dictKeys = keys(dict);
+    return Future.all(values(dict)).map((values) =>
+      Object.fromEntries(zip(dictKeys, values)),
+    );
   };
 
   tag: "Pending" | "Cancelled" | "Resolved";

--- a/src/OptionResult.ts
+++ b/src/OptionResult.ts
@@ -1,3 +1,6 @@
+import { keys, values } from "./Dict";
+import { zip } from "./ZipUnzip";
+
 export class Option<A> {
   /**
    * Create an AsyncData.Some value
@@ -80,6 +83,20 @@ export class Option<A> {
       });
       index++;
     }
+  };
+
+  /**
+   * Turns an dict of options into a options of dict
+   */
+  static allFromDict = <Dict extends Record<string, Option<any>>>(
+    dict: Dict,
+  ): Option<{
+    -readonly [P in keyof Dict]: Dict[P] extends Option<infer T> ? T : never;
+  }> => {
+    const dictKeys = keys(dict);
+    return Option.all(values(dict)).map((values) =>
+      Object.fromEntries(zip(dictKeys, values)),
+    );
   };
 
   static equals = <A>(
@@ -322,6 +339,29 @@ export class Result<A, E> {
       });
       index++;
     }
+  };
+
+  /**
+   * Turns an dict of results into a results of dict
+   */
+  static allFromDict = <Dict extends Record<string, Result<any, any>>>(
+    dict: Dict,
+  ): Result<
+    {
+      -readonly [P in keyof Dict]: Dict[P] extends Result<infer T, any>
+        ? T
+        : never;
+    },
+    {
+      -readonly [P in keyof Dict]: Dict[P] extends Result<any, infer E>
+        ? E
+        : never;
+    }[keyof Dict]
+  > => {
+    const dictKeys = keys(dict);
+    return Result.all(values(dict)).map((values) =>
+      Object.fromEntries(zip(dictKeys, values)),
+    );
   };
 
   static equals = <A, E>(

--- a/src/ZipUnzip.ts
+++ b/src/ZipUnzip.ts
@@ -1,0 +1,51 @@
+export const unzip = <TupleArray extends [any, any][]>(array: TupleArray) => {
+  const length = array.length;
+  const arrayA = Array(length);
+  const arrayB = Array(length);
+  let index = -1;
+  while (++index < length) {
+    const match = array[index];
+    if (match !== undefined) {
+      arrayA[index] = match[0];
+      arrayB[index] = match[1];
+    }
+  }
+  return [arrayA, arrayB] as unknown as [
+    {
+      [I in keyof TupleArray]: TupleArray[I] extends [any, any]
+        ? TupleArray[I][0] extends infer T
+          ? T
+          : never
+        : never;
+    },
+    {
+      [I in keyof TupleArray]: TupleArray[I] extends [any, any]
+        ? TupleArray[I][1] extends infer T
+          ? T
+          : never
+        : never;
+    },
+  ];
+};
+
+export const zip = <ArrayA extends any[], ArrayB extends any[]>(
+  arrayA: ArrayA,
+  arrayB: ArrayB,
+) => {
+  const length = Math.min(arrayA.length, arrayB.length);
+  const array = Array(length);
+  let index = -1;
+  while (++index < length) {
+    array[index] = [arrayA[index], arrayB[index]];
+  }
+  return array as unknown as Array<
+    [
+      {
+        [I in keyof ArrayA]: ArrayA[I] extends infer T ? T : never;
+      }[number],
+      {
+        [I in keyof ArrayB]: ArrayB[I] extends infer T ? T : never;
+      }[number],
+    ]
+  >;
+};

--- a/test/Array.test.ts
+++ b/test/Array.test.ts
@@ -7,6 +7,8 @@ import {
   isArray,
   keepMap,
   of,
+  unzip,
+  zip,
 } from "../src/Array";
 import { Option } from "../src/OptionResult";
 
@@ -65,4 +67,33 @@ test("Array.of", () => {
 
   expect(isArray([])).toEqual(true);
   expect(isArray({ length: 0 })).toEqual(false);
+});
+
+test("Array.zip", () => {
+  expect(zip([1, 2, 3], ["one", "two", "three"])).toEqual([
+    [1, "one"],
+    [2, "two"],
+    [3, "three"],
+  ]);
+  expect(zip([1, 2], ["one", "two", "three"])).toEqual([
+    [1, "one"],
+    [2, "two"],
+  ]);
+  expect(zip([1, 2, 3], ["one", "two"])).toEqual([
+    [1, "one"],
+    [2, "two"],
+  ]);
+});
+
+test("Array.unzip", () => {
+  expect(
+    unzip([
+      [1, "one"],
+      [2, "two"],
+      [3, "three"],
+    ]),
+  ).toEqual([
+    [1, 2, 3],
+    ["one", "two", "three"],
+  ]);
 });

--- a/test/AsyncData.test.ts
+++ b/test/AsyncData.test.ts
@@ -184,6 +184,45 @@ test("AsyncData.all", () => {
   ).toEqual(AsyncData.NotAsked());
 });
 
+test("AsyncData.allFromDict", () => {
+  expect(AsyncData.allFromDict({})).toEqual(AsyncData.Done({}));
+  expect(
+    AsyncData.allFromDict({
+      a: AsyncData.Done(1),
+      b: AsyncData.Done(2),
+      c: AsyncData.Done(3),
+    }),
+  ).toEqual(AsyncData.Done({ a: 1, b: 2, c: 3 }));
+  expect(
+    AsyncData.allFromDict({
+      a: AsyncData.NotAsked(),
+      b: AsyncData.Done(2),
+      c: AsyncData.Done(3),
+    }),
+  ).toEqual(AsyncData.NotAsked());
+  expect(
+    AsyncData.allFromDict({
+      a: AsyncData.Done(1),
+      b: AsyncData.Loading(),
+      c: AsyncData.Done(3),
+    }),
+  ).toEqual(AsyncData.Loading());
+  expect(
+    AsyncData.allFromDict({
+      a: AsyncData.Loading(),
+      b: AsyncData.NotAsked(),
+      c: AsyncData.Done(3),
+    }),
+  ).toEqual(AsyncData.Loading());
+  expect(
+    AsyncData.allFromDict({
+      a: AsyncData.NotAsked(),
+      b: AsyncData.Loading(),
+      c: AsyncData.Done(3),
+    }),
+  ).toEqual(AsyncData.NotAsked());
+});
+
 test("ts-pattern", () => {
   expect(
     match(AsyncData.Done(1))

--- a/test/Future.test.ts
+++ b/test/Future.test.ts
@@ -69,6 +69,23 @@ test("Future all", async () => {
   expect(result).toEqual([1, 2, 3, 4]);
 });
 
+test("Future allFromDict", async () => {
+  const result = await Future.allFromDict({
+    a: Future.value(1),
+    b: Future.make((resolve) => {
+      setTimeout(() => resolve(2), 50);
+    }),
+    c: Future.make((resolve) => {
+      setTimeout(() => resolve(3), 25);
+    }),
+    d: Future.make((resolve) => {
+      setTimeout(() => resolve(undefined), 75);
+    }).map(() => 4),
+  });
+
+  expect(result).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+});
+
 test("Future mapOk", async () => {
   const result = await Future.value(Result.Ok("one")).mapOk((x) => `${x}!`);
   expect(result).toEqual(Result.Ok("one!"));

--- a/test/Option.test.ts
+++ b/test/Option.test.ts
@@ -129,6 +129,31 @@ test("Option.all", () => {
   );
 });
 
+test("Option.allFromDict", () => {
+  expect(Option.allFromDict({})).toEqual(Option.Some({}));
+  expect(
+    Option.allFromDict({
+      a: Option.Some(1),
+      b: Option.Some(2),
+      c: Option.Some(3),
+    }),
+  ).toEqual(Option.Some({ a: 1, b: 2, c: 3 }));
+  expect(
+    Option.allFromDict({
+      a: Option.None(),
+      b: Option.Some(2),
+      c: Option.Some(3),
+    }),
+  ).toEqual(Option.None());
+  expect(
+    Option.allFromDict({
+      a: Option.Some(1),
+      b: Option.None(),
+      c: Option.Some(3),
+    }),
+  ).toEqual(Option.None());
+});
+
 test("ts-pattern", () => {
   expect(
     match(Option.Some(1))

--- a/test/Result.test.ts
+++ b/test/Result.test.ts
@@ -181,6 +181,27 @@ test("Result.all", () => {
   );
 });
 
+test("Result.allFromDict", () => {
+  expect(Result.allFromDict({})).toEqual(Result.Ok({}));
+  expect(
+    Result.allFromDict({ a: Result.Ok(1), b: Result.Ok(2), c: Result.Ok(3) }),
+  ).toEqual(Result.Ok({ a: 1, b: 2, c: 3 }));
+  expect(
+    Result.allFromDict({
+      a: Result.Error(1),
+      b: Result.Ok(2),
+      c: Result.Ok(3),
+    }),
+  ).toEqual(Result.Error(1));
+  expect(
+    Result.allFromDict({
+      a: Result.Ok(1),
+      b: Result.Error(2),
+      c: Result.Ok(3),
+    }),
+  ).toEqual(Result.Error(2));
+});
+
 test("ts-pattern", () => {
   expect(
     match(Result.Ok(1))


### PR DESCRIPTION
## allFromDict

Like `all` but allows you to name things

- `Future.allFromDict`
- `Result.allFromDict`
- `Option.allFromDict`
- `AsyncData.allFromDict`

```ts
Future.allFromDict({
  a: Future.value(1),
  b: Future.value(2),
  c: Future.value(3),
});
// Future<{a: 1, b: 2, c: 3}>

Future.allFromDict({
  a: Future.value(Result.Ok(1)),
  b: Future.value(Result.Ok(2)),
  c: Future.value(Result.Ok(3)),
})
  .map(Result.allFromDict);
// Future<Result.Ok<{a: 1, b: 2, c: 3}>>
```

## Array.zip/unzip

Useful for grouping elements by pairs