### PR TITLE
Improve Dict helpers

### DIFF
--- a/src/Boxed.ts
+++ b/src/Boxed.ts
@@ -1,20 +1,8 @@
-import * as Array from "./Array";
-import { AsyncData } from "./AsyncData";
-import { Deferred } from "./Deferred";
-import * as Dict from "./Dict";
-import { Future } from "./Future";
-import { Lazy } from "./Lazy";
-import { Option, Result } from "./OptionResult";
-import * as Serializer from "./Serializer";
-
-export {
-  Array,
-  AsyncData,
-  Deferred,
-  Dict,
-  Future,
-  Lazy,
-  Option,
-  Result,
-  Serializer,
-};
+export * as Array from "./Array";
+export { AsyncData } from "./AsyncData";
+export { Deferred } from "./Deferred";
+export * as Dict from "./Dict";
+export { Future } from "./Future";
+export { Lazy } from "./Lazy";
+export { Option, Result } from "./OptionResult";
+export * as Serializer from "./Serializer";

--- a/src/Dict.ts
+++ b/src/Dict.ts
@@ -1,21 +1,12 @@
-export function entries<T>(value: T) {
-  return Object.entries(value) as NonNullable<
-    {
-      [K in keyof T]: K extends string ? [K, T[K]] : never;
-    }[keyof T]
-  >[];
-}
+type GenericRecord = Record<string | number | symbol, unknown>;
 
-export function keys<T>(value: T) {
-  return Object.keys(value) as NonNullable<
-    {
-      [K in keyof T]: K extends string ? K : never;
-    }[keyof T]
-  >[];
-}
-
-export function values<T>(value: T) {
-  return Object.values(value) as {
-    [K in keyof T]: K extends string ? T[K] : never;
+export const entries = <T extends GenericRecord>(value: T) =>
+  Object.entries(value) as {
+    [K in keyof T]: [K, T[K]];
   }[keyof T][];
-}
+
+export const keys = <T extends GenericRecord>(value: T) =>
+  Object.keys(value) as (keyof T)[];
+
+export const values = <T extends GenericRecord>(value: T) =>
+  Object.values(value) as T[keyof T][];

--- a/src/OptionResult.ts
+++ b/src/OptionResult.ts
@@ -3,7 +3,7 @@ import { zip } from "./ZipUnzip";
 
 export class Option<A> {
   /**
-   * Create an AsyncData.Some value
+   * Create an Option.Some value
    */
   static Some = <A = never>(value: A): Option<A> => {
     const option = Object.create(protoOption) as Option<A>;


### PR DESCRIPTION
This improve #17.

Records can use `string | number | symbol` as key. Regarding that, we can enforce a type constraint and simplify a lot the type casts.

(The current implementation only support `string` keys, `Dict.keys({ 10: "foo" })` returns `never`)