### PR TITLE
Rename Future.get -> Future.onResolve

### DIFF
--- a/benchmark/src/future.js
+++ b/benchmark/src/future.js
@@ -6,7 +6,7 @@ const suite = new Benchmark.Suite();
 suite.add("Future", () => {
   Future.value(1)
     .map((x) => x + 1)
-    .get((v) => {});
+    .onResolve((v) => {});
 });
 
 suite.add("Promise", {

--- a/docs/docs/deferred.md
+++ b/docs/docs/deferred.md
@@ -13,7 +13,7 @@ import { Deferred } from "@swan-io/boxed";
 const [future, resolve] = Deferred.make<string>();
 
 // subscribe to the promise
-future.get(console.log);
+future.onResolve(console.log);
 
 // resolve from elsewhere
 resolve("Hello!");

--- a/docs/docs/future.md
+++ b/docs/docs/future.md
@@ -40,16 +40,16 @@ const otherFuture = Future.make((resolve) => {
 
 ## Methods
 
-### .get(f)
+### .onResolve(f)
 
 ```ts
-Future<A>.get(func: (value: A) => void): void
+Future<A>.onResolve(func: (value: A) => void): void
 ```
 
 Runs `f` with the future value as argument when available.
 
 ```ts title="Examples"
-Future.value(1).get(console.log);
+Future.value(1).onResolve(console.log);
 // Log: 1
 ```
 

--- a/src/Future.ts
+++ b/src/Future.ts
@@ -171,7 +171,10 @@ export class Future<A> {
       }
     });
 
-    this.onCancel(future.cancel);
+    this.onCancel(() => {
+      future.cancel();
+    });
+
     return future;
   }
 
@@ -193,7 +196,7 @@ export class Future<A> {
       this.onResolve((value) => {
         const returnedFuture = func(value);
         returnedFuture.onResolve(resolve);
-        returnedFuture.onCancel(future.cancel);
+        returnedFuture.onCancel(() => future.cancel());
       });
 
       if (propagateCancel) {
@@ -203,7 +206,10 @@ export class Future<A> {
       }
     });
 
-    this.onCancel(future.cancel);
+    this.onCancel(() => {
+      future.cancel();
+    });
+
     return future;
   }
 

--- a/src/Future.ts
+++ b/src/Future.ts
@@ -119,7 +119,7 @@ export class Future<A> {
   /**
    * Runs the callback with the future value when resolved
    */
-  get(func: (value: A) => void) {
+  onResolve(func: (value: A) => void) {
     if (this._state.tag === "Pending") {
       this._state.resolveCallbacks = this._state.resolveCallbacks ?? [];
       this._state.resolveCallbacks.push(func);
@@ -160,7 +160,7 @@ export class Future<A> {
    */
   map<B>(func: (value: A) => B, propagateCancel = false): Future<B> {
     const future = Future.make<B>((resolve) => {
-      this.get((value) => {
+      this.onResolve((value) => {
         resolve(func(value));
       });
 
@@ -171,15 +171,12 @@ export class Future<A> {
       }
     });
 
-    this.onCancel(() => {
-      future.cancel();
-    });
-
+    this.onCancel(future.cancel);
     return future;
   }
 
   then(func: (value: A) => void) {
-    this.get(func);
+    this.onResolve(func);
     return this;
   }
 
@@ -193,10 +190,10 @@ export class Future<A> {
     propagateCancel = false,
   ): Future<B> {
     const future = Future.make<B>((resolve) => {
-      this.get((value) => {
+      this.onResolve((value) => {
         const returnedFuture = func(value);
-        returnedFuture.get(resolve);
-        returnedFuture.onCancel(() => future.cancel());
+        returnedFuture.onResolve(resolve);
+        returnedFuture.onCancel(future.cancel);
       });
 
       if (propagateCancel) {
@@ -206,10 +203,7 @@ export class Future<A> {
       }
     });
 
-    this.onCancel(() => {
-      future.cancel();
-    });
-
+    this.onCancel(future.cancel);
     return future;
   }
 
@@ -217,7 +211,7 @@ export class Future<A> {
    * Runs the callback and returns `this`
    */
   tap(this: Future<A>, func: (value: A) => unknown): Future<A> {
-    this.get(func);
+    this.onResolve(func);
     return this;
   }
 
@@ -230,7 +224,7 @@ export class Future<A> {
     this: Future<Result<A, E>>,
     func: (value: A) => unknown,
   ): Future<Result<A, E>> {
-    this.get((value) => {
+    this.onResolve((value) => {
       value.match({
         Ok: (value) => func(value),
         Error: () => {},
@@ -249,7 +243,7 @@ export class Future<A> {
     this: Future<Result<A, E>>,
     func: (value: E) => unknown,
   ): Future<Result<A, E>> {
-    this.get((value) => {
+    this.onResolve((value) => {
       value.match({
         Ok: () => {},
         Error: (error) => func(error),
@@ -354,7 +348,7 @@ export class Future<A> {
    */
   toPromise(): Promise<A> {
     return new Promise((resolve) => {
-      this.get(resolve);
+      this.onResolve(resolve);
     });
   }
 
@@ -365,7 +359,7 @@ export class Future<A> {
    */
   resultToPromise<A, E>(this: Future<Result<A, E>>): Promise<A> {
     return new Promise((resolve, reject) => {
-      this.get((value) => {
+      this.onResolve((value) => {
         value.match({
           Ok: resolve,
           Error: reject,

--- a/test/Deferred.test.ts
+++ b/test/Deferred.test.ts
@@ -4,7 +4,7 @@ import { Deferred } from "../src/Deferred";
 test("Deferred", async () => {
   const [future, resolve] = Deferred.make();
 
-  future.get((n) => {
+  future.onResolve((n) => {
     expect(n).toEqual(1);
   });
 

--- a/test/Future.test.ts
+++ b/test/Future.test.ts
@@ -41,7 +41,7 @@ test("Future flatMap", async () => {
   expect(result).toBe(60);
 });
 
-test("Future multiple get", async () => {
+test("Future multiple onResolve", async () => {
   let count = 0;
   const future = Future.make<number>((resolve) => {
     count++;
@@ -50,8 +50,8 @@ test("Future multiple get", async () => {
 
   const result = await future;
 
-  future.get(() => {});
-  future.get(() => {});
+  future.onResolve(() => {});
+  future.onResolve(() => {});
 
   expect(result).toBe(1);
 });


### PR DESCRIPTION
Renaming `Future.get` to `Future.onResolve` (`future.get(console.log)`  -> `future.onResolve(console.log)`) in order to:

- Align with `Future.onCancel`
- Avoid confusion with Option / Result / Lazy / AsyncData `get` (with `() => A` method signatures)