### PR TITLE
fix: tap function should't have return value

### DIFF
--- a/docs/docs/async-data.md
+++ b/docs/docs/async-data.md
@@ -218,7 +218,7 @@ const valueToDisplay = result.match({
 ### .tap(func)
 
 ```ts
-AsyncData<A>.tap(func: (asyncData: AsyncData<A>) => unknown): AsyncData<A>
+AsyncData<A>.tap(func: (asyncData: AsyncData<A>) => void): AsyncData<A>
 ```
 
 Executes `func` with `asyncData`, and returns `asyncData`. Useful for logging and debugging.

--- a/docs/docs/future-result.md
+++ b/docs/docs/future-result.md
@@ -137,7 +137,7 @@ Future.value(Result.Error("Error")).flatMapError((error) =>
 ### .tapOk(f)
 
 ```ts
-Future<Result<A, E>>.tapOk(func: (value: A) => unknown): Future<Result<A, E>>
+Future<Result<A, E>>.tapOk(func: (value: A) => void): Future<Result<A, E>>
 ```
 
 Runs `f` if value is `Ok` with the future value, and returns the original future. Useful for debugging.
@@ -149,7 +149,7 @@ future.tapOk(console.log);
 ### .tapError(f)
 
 ```ts
-Future<Result<A, E>>.tapError(func: (value: E) => unknown): Future<Result<A, E>>
+Future<Result<A, E>>.tapError(func: (value: E) => void): Future<Result<A, E>>
 ```
 
 Runs `f` if value is `Error` with the future value, and returns the original future. Useful for debugging.

--- a/docs/docs/future.md
+++ b/docs/docs/future.md
@@ -96,7 +96,7 @@ Future.value(3).flatMap((x) => Future.value(x * 2));
 ### .tap(f)
 
 ```ts
-Future<A>.tap(func: (value: A) => unknown): Future<A>
+Future<A>.tap(func: (value: A) => void): Future<A>
 ```
 
 Runs `f` with the future value, and returns the original future. Useful for debugging.

--- a/docs/docs/option.md
+++ b/docs/docs/option.md
@@ -219,7 +219,7 @@ const valueToDisplay = option.match({
 ### .tap(func)
 
 ```ts
-Option<A>.tap(func: (option: Option<A>) => unknown): Option<A>
+Option<A>.tap(func: (option: Option<A>) => void): Option<A>
 ```
 
 Executes `func` with `option`, and returns `option`. Useful for logging and debugging.

--- a/docs/docs/result.md
+++ b/docs/docs/result.md
@@ -278,7 +278,7 @@ const valueToDisplay = result.match({
 ### .tap(func)
 
 ```ts
-Result<A, E>.tap(func: (result: Result<A, E>) => unknown): Result<A, E>
+Result<A, E>.tap(func: (result: Result<A, E>) => void): Result<A, E>
 ```
 
 Executes `func` with `result`, and returns `result`. Useful for logging and debugging.
@@ -290,7 +290,7 @@ result.tap(console.log).map((x) => x * 2);
 ### .tapOk(func)
 
 ```ts
-Result<A, E>.tapOk(func: (value: A) => unknown): Result<A, E>
+Result<A, E>.tapOk(func: (value: A) => void): Result<A, E>
 ```
 
 Executes `func` with `ok`, and returns `result`. Useful for logging and debugging. No-op if `result` is an error.
@@ -302,7 +302,7 @@ result.tapOk(console.log).map((x) => x * 2);
 ### .tapError(func)
 
 ```ts
-Result<A, E>.tapError(func: (error: E) => unknown): Result<A, E>
+Result<A, E>.tapError(func: (error: E) => void): Result<A, E>
 ```
 
 Executes `func` with `error`, and returns `result`. Useful for logging and debugging. No-op if `result` is ok.

--- a/src/AsyncData.ts
+++ b/src/AsyncData.ts
@@ -45,7 +45,7 @@ interface IAsyncData<A> {
    */
   tap(
     this: AsyncData<A>,
-    func: (asyncData: AsyncData<A>) => unknown,
+    func: (asyncData: AsyncData<A>) => void,
   ): AsyncData<A>;
 
   /**
@@ -123,7 +123,7 @@ const asyncDataProto = (<A>(): IAsyncData<A> => ({
       : config.NotAsked();
   },
 
-  tap(this: AsyncData<A>, func: (asyncData: AsyncData<A>) => unknown) {
+  tap(this: AsyncData<A>, func: (asyncData: AsyncData<A>) => void) {
     func(this);
     return this;
   },

--- a/src/Future.ts
+++ b/src/Future.ts
@@ -216,7 +216,7 @@ export class Future<A> {
   /**
    * Runs the callback and returns `this`
    */
-  tap(this: Future<A>, func: (value: A) => unknown): Future<A> {
+  tap(this: Future<A>, func: (value: A) => void): Future<A> {
     this.onResolve(func);
     return this;
   }
@@ -228,7 +228,7 @@ export class Future<A> {
    */
   tapOk<A, E>(
     this: Future<Result<A, E>>,
-    func: (value: A) => unknown,
+    func: (value: A) => void,
   ): Future<Result<A, E>> {
     this.onResolve((value) => {
       value.match({
@@ -247,7 +247,7 @@ export class Future<A> {
    */
   tapError<A, E>(
     this: Future<Result<A, E>>,
-    func: (value: E) => unknown,
+    func: (value: E) => void,
   ): Future<Result<A, E>> {
     this.onResolve((value) => {
       value.match({

--- a/src/OptionResult.ts
+++ b/src/OptionResult.ts
@@ -35,7 +35,7 @@ interface IOption<A> {
   /**
    * Runs the callback and returns `this`
    */
-  tap(this: Option<A>, func: (option: Option<A>) => unknown): Option<A>;
+  tap(this: Option<A>, func: (option: Option<A>) => void): Option<A>;
 
   /**
    * Converts the Option\<A> to a `A | undefined`
@@ -100,7 +100,7 @@ const optionProto = (<A>(): IOption<A> => ({
     return this.tag === "Some" ? config.Some(this.value) : config.None();
   },
 
-  tap(this: Option<A>, func: (option: Option<A>) => unknown) {
+  tap(this: Option<A>, func: (option: Option<A>) => void) {
     func(this);
     return this;
   },
@@ -303,18 +303,18 @@ interface IResult<A, E> {
    */
   tap(
     this: Result<A, E>,
-    func: (result: Result<A, E>) => unknown,
+    func: (result: Result<A, E>) => void,
   ): Result<A, E>;
 
   /**
    * Runs the callback if ok and returns `this`
    */
-  tapOk(this: Result<A, E>, func: (value: A) => unknown): Result<A, E>;
+  tapOk(this: Result<A, E>, func: (value: A) => void): Result<A, E>;
 
   /**
    * Runs the callback if error and returns `this`
    */
-  tapError(this: Result<A, E>, func: (error: E) => unknown): Result<A, E>;
+  tapError(this: Result<A, E>, func: (error: E) => void): Result<A, E>;
 
   /**
    * Return an option of the value
@@ -392,19 +392,19 @@ const resultProto = (<A, E>(): IResult<A, E> => ({
     return this.tag === "Ok" ? config.Ok(this.value) : config.Error(this.value);
   },
 
-  tap(this: Result<A, E>, func: (result: Result<A, E>) => unknown) {
+  tap(this: Result<A, E>, func: (result: Result<A, E>) => void) {
     func(this);
     return this;
   },
 
-  tapOk(this: Result<A, E>, func: (value: A) => unknown) {
+  tapOk(this: Result<A, E>, func: (value: A) => void) {
     if (this.tag === "Ok") {
       func(this.value);
     }
     return this;
   },
 
-  tapError(this: Result<A, E>, func: (error: E) => unknown) {
+  tapError(this: Result<A, E>, func: (error: E) => void) {
     if (this.tag === "Error") {
       func(this.value);
     }


### PR DESCRIPTION
The void type is notably used to describe the return value of functions that do not return anything.
The unknown type is similar to any, in that it also represents a type that is apriori not known

rxjs tap:
```
tap<T>(next: (value: T) => void):
```