### PR TITLE
Doc: fix ts-pattern interop code examples

### DIFF
--- a/docs/docs/async-data.md
+++ b/docs/docs/async-data.md
@@ -282,13 +282,13 @@ AsyncData.allFromDict({
 ## TS Pattern interop
 
 ```ts title="Examples"
-import { match, select } from "ts-pattern";
+import { match, P } from "ts-pattern";
 import { AsyncData } from "@swan-io/boxed";
 
 match(asyncData)
-  .with(AsyncData.pattern.Done(select()), (value) => console.log(value))
-  .with(AsyncData.pattern.Loading), () => "Loading ...")
-  .with(AsyncData.pattern.NotAsked), () => "")
+  .with(AsyncData.pattern.Done(P.select()), (value) => console.log(value))
+  .with(AsyncData.pattern.Loading, () => "Loading ...")
+  .with(AsyncData.pattern.NotAsked, () => "")
   .exhaustive();
 ```
 

--- a/docs/docs/option.md
+++ b/docs/docs/option.md
@@ -265,11 +265,11 @@ Option.allFromDict({ a: Option.None(), b: Option.Some(2), c: Option.Some(3) });
 ## TS Pattern interop
 
 ```ts title="Examples"
-import { match, select } from "ts-pattern";
+import { match, P } from "ts-pattern";
 import { Option } from "@swan-io/boxed";
 
 match(myOption)
-  .with(Option.pattern.Some(select()), (value) => console.log(value))
+  .with(Option.pattern.Some(P.select()), (value) => console.log(value))
   .with(Option.pattern.None, () => "No value")
   .exhaustive();
 ```

--- a/docs/docs/result.md
+++ b/docs/docs/result.md
@@ -402,12 +402,12 @@ const b = Result.fromOption(Option.None(), "NotFound");
 ## TS Pattern interop
 
 ```ts
-import { match, select } from "ts-pattern";
+import { match, P } from "ts-pattern";
 import { Result } from "@swan-io/boxed";
 
 match(myResult)
-  .with(Result.pattern.Ok(select()), (value) => console.log(value))
-  .with(Result.pattern.Error(select()), (error) => {
+  .with(Result.pattern.Ok(P.select()), (value) => console.log(value))
+  .with(Result.pattern.Error(P.select()), (error) => {
     console.error(error);
     return "fallback";
   })


### PR DESCRIPTION
Hello!

Before giving the description of this PR, I just want to say `Boxed` documentation helps me a lot to get started. So thanks a lot for making this package with a so good documentation!

I started to use it with `ts-pattern` and I discover some minor issues in code examples:
- `ts-pattern` last version (`v4.1.3` when I write this PR) doesn't export `select` but we can find it in `P`
- there was 2 closing parenthesis too early in `AsyncData` doc

The goal of this PR is fixing those 2 issues.