### PR TITLE
Add .any method on the Option class

### DIFF
--- a/src/OptionResult.ts
+++ b/src/OptionResult.ts
@@ -252,6 +252,19 @@ export const Option = {
       : a.tag === b.tag;
   },
 
+  any<DataType extends any, Options extends Option<DataType>[]>(
+    options: Options,
+  ): Some<DataType>[] {
+    const output: Some<DataType>[] = [];
+    for (const item of options) {
+      if (item.isSome()) {
+        output.push(item);
+      }
+    }
+
+    return output;
+  },
+
   P: optionPattern,
   pattern: optionPattern,
 };

--- a/test/Option.test.ts
+++ b/test/Option.test.ts
@@ -190,3 +190,12 @@ test("Option.isOption", async () => {
   expect(Option.isOption([])).toEqual(false);
   expect(Option.isOption({})).toEqual(false);
 });
+
+test("Option.any", () => {
+  const sum41 = [Option.Some(4), Option.Some(1), Option.None()];
+  expect(Option.any(sum41)).toStrictEqual([Option.Some(4), Option.Some(1)]);
+
+  const listOfNones = [Option.None(), Option.None(), Option.None()];
+  expect(Option.any(listOfNones)).toStrictEqual([]);
+  expect(Option.any([])).toStrictEqual([]);
+});


### PR DESCRIPTION
Add a tiny `.any` function that filters out `None`s from a `Option<T>[]`. See tests for usage

Not a fan over the generics used, if I do:
```typescript
const out = Option.any(sum41) // const out = Some<unknown>[]
```
which isn't the best...