### PR TITLE
Let Array methods take ReadonlyArray arguments

### DIFF
--- a/src/Array.ts
+++ b/src/Array.ts
@@ -7,7 +7,7 @@ export const of = Array.of;
 export const isArray = Array.isArray;
 
 export const findMap = <A, B>(
-  array: Array<A>,
+  array: ReadonlyArray<A>,
   func: (item: A) => Option<B>,
 ): Option<B> => {
   let index = -1;
@@ -22,7 +22,7 @@ export const findMap = <A, B>(
 };
 
 export const filterMap = <A, B>(
-  array: Array<A>,
+  array: ReadonlyArray<A>,
   func: (item: A) => Option<B>,
 ): Array<B> => {
   const result: Array<B> = [];
@@ -36,7 +36,7 @@ export const filterMap = <A, B>(
 };
 
 export const find = <A>(
-  array: Array<A>,
+  array: ReadonlyArray<A>,
   func: (item: A) => boolean,
 ): Option<A> => {
   let index = -1;
@@ -50,7 +50,7 @@ export const find = <A>(
 };
 
 export const findIndex = <A>(
-  array: Array<A>,
+  array: ReadonlyArray<A>,
   func: (item: A) => boolean,
 ): Option<number> => {
   let index = -1;
@@ -71,7 +71,7 @@ const defaultCompare = <A>(a: A, b: A) => {
 };
 
 export const binarySearchBy = <A>(
-  sortedArray: Array<A>,
+  sortedArray: ReadonlyArray<A>,
   key: A,
   compare = defaultCompare,
 ) => {


### PR DESCRIPTION
The current version does not allow this:

```typescript
import { Option } from '@swan-io/boxed';

const things: readonly string[] = ['a', 'b'];

// Error: Property 'findIndex' does not exist on type 'ArrayConstructor'
const index Array.findIndex(things, e => e === 'x');
```

This changes the argument type of arrays to `ReadonlyArray`, which makes this code valid. I dont *think* there are any other consequences since readable arrays are assignable to readonly arrays in arguments.