### PR TITLE
Fix 78: Serializer.encode throws for null and undefined

### DIFF
--- a/src/Serializer.ts
+++ b/src/Serializer.ts
@@ -6,6 +6,9 @@ export const encode = (value: any, indent?: number | undefined) => {
   return JSON.stringify(
     value,
     (key, value) => {
+      if (value == null) {
+        return value;
+      }
       if (typeof value[BOXED_TYPE] === "string") {
         return { ...value, __boxed_type__: value[BOXED_TYPE] };
       }

--- a/test/Serializer.test.ts
+++ b/test/Serializer.test.ts
@@ -12,6 +12,13 @@ test("Serializer", () => {
           nothing: Option.None(),
           loading: AsyncData.Loading(),
           notAsked: AsyncData.NotAsked(),
+          nullable: null,
+          undefinable: undefined,
+          string: "Hello",
+          number: 1209,
+          boolean: true,
+          array: [1, 2, 3],
+          object: { a: 1, b: "two" },
         }),
       ),
     ),
@@ -22,4 +29,6 @@ test("Serializer", () => {
   expect(decode(encode(start)).value.map(() => "Hello")).toEqual(
     AsyncData.Done("Hello"),
   );
+  expect(encode(null)).toEqual("null");
+  expect(encode(undefined)).toEqual(undefined);
 });


### PR DESCRIPTION
This resolves #78.

This does diverge from previous behavior by encoding null.