### PR TITLE
Fix: Result.fromJSON return type

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "format": "prettier '**/*' -u -w",
     "prepack": "yarn test && yarn build",
     "test": "vitest run",
+    "test:typecheck": "tsc --noEmit -p tsconfig.test.json",
     "typecheck": "tsc --noEmit",
     "benchmark": "node benchmark/src/option && node benchmark/src/result && node benchmark/src/future && node benchmark/src/future-result"
   },

--- a/src/OptionResult.ts
+++ b/src/OptionResult.ts
@@ -421,7 +421,7 @@ class __Result<A, E> {
     return false;
   };
 
-  static fromJSON = <A, E>(value: JsonResult<A, E>) => {
+  static fromJSON = <A, E>(value: JsonResult<A, E>): Result<A, E> => {
     return value.tag === "Ok"
       ? Result.Ok(value.value)
       : Result.Error(value.error);

--- a/test/AsyncData.test.ts
+++ b/test/AsyncData.test.ts
@@ -380,3 +380,12 @@ test("AsyncData isAsyncData", async () => {
   expect(AsyncData.isAsyncData([])).toEqual(false);
   expect(AsyncData.isAsyncData({})).toEqual(false);
 });
+
+test("AsyncData JSON serialization", () => {
+  const data = AsyncData.Loading<number>();
+  expect(
+    AsyncData.fromJSON(data.toJSON()).tap(() => {
+      // use async data
+    }),
+  ).toEqual(data);
+});

--- a/test/Future.test.ts
+++ b/test/Future.test.ts
@@ -464,7 +464,7 @@ test("Future concurrent", async () => {
           --parallel;
         }),
       () =>
-        Future.make<4>((resolve) => {
+        Future.make((resolve) => {
           expect(++parallel).toBeLessThanOrEqual(2);
           setTimeout(() => resolve(undefined), 75);
         })

--- a/test/Option.test.ts
+++ b/test/Option.test.ts
@@ -202,3 +202,12 @@ test("Option.isOption", async () => {
   expect(Option.isOption([])).toEqual(false);
   expect(Option.isOption({})).toEqual(false);
 });
+
+test("Option JSON serialization", () => {
+  const option = Option.None();
+  expect(
+    Option.fromJSON(option.toJSON()).tap(() => {
+      // Use option
+    }),
+  ).toEqual(option);
+});

--- a/test/Result.test.ts
+++ b/test/Result.test.ts
@@ -253,3 +253,19 @@ test("Result.isResult", async () => {
   expect(Result.isResult([])).toEqual(false);
   expect(Result.isResult({})).toEqual(false);
 });
+
+test("Result JSON serialization", async () => {
+  const resultOk = Result.Ok({ thing: "hello" });
+  expect(
+    Result.fromJSON(resultOk.toJSON()).tap(() => {
+      // Use result
+    }),
+  ).toEqual(resultOk);
+
+  const resultError = Result.Error(new Error("Oops"));
+  expect(
+    Result.fromJSON(resultError.toJSON()).tap(() => {
+      // Use result
+    }),
+  ).toEqual(resultError);
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*.test.ts"],
+  "exclude": ["node_modules", "dist"],
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+}


### PR DESCRIPTION
Fixes #80

Adds an explicit return type to `Result.fromJSON` so that the return type isn't effectively inferred as `Ok<A> & Ok<never> | Error<E> & Error<never>` which is an impossible type to have.