### PR TITLE
Improve match return types inference

### DIFF
--- a/src/AsyncData.ts
+++ b/src/AsyncData.ts
@@ -269,14 +269,14 @@ class __AsyncData<A> {
     return mapper((this as Done<A>).value);
   }
 
-  match<B>(
+  match<B1, B2 = B1, B3 = B1>(
     this: AsyncData<A>,
     config: {
-      Done: (value: A) => B;
-      Loading: () => B;
-      NotAsked: () => B;
+      Done: (value: A) => B1;
+      Loading: () => B2;
+      NotAsked: () => B3;
     },
-  ): B {
+  ): B1 | B2 | B3 {
     if (this === NOT_ASKED) {
       return config.NotAsked();
     }

--- a/src/OptionResult.ts
+++ b/src/OptionResult.ts
@@ -237,10 +237,10 @@ class __Option<A> {
   /**
    * Explodes the Option given its case
    */
-  match<B>(
+  match<B1, B2 = B1>(
     this: Option<A>,
-    config: { Some: (value: A) => B; None: () => B },
-  ): B {
+    config: { Some: (value: A) => B1; None: () => B2 },
+  ): B1 | B2 {
     if (this === NONE) {
       return config.None();
     }
@@ -604,10 +604,10 @@ class __Result<A, E> {
   /**
    * Explodes the Result given its case
    */
-  match<B>(
+  match<B1, B2 = B1>(
     this: Result<A, E>,
-    config: { Ok: (value: A) => B; Error: (error: E) => B },
-  ): B {
+    config: { Ok: (value: A) => B1; Error: (error: E) => B2 },
+  ): B1 | B2 {
     return this.tag === "Ok" ? config.Ok(this.value) : config.Error(this.error);
   }
 


### PR DESCRIPTION
Fixes #89 

I'm not a fan of the naming (`B1`, `B2`, etc.), but not a fan of the initial naming too (`A`, `B`).
But maybe is that OK for you? It could also be:

```ts
match<SomeReturnType, NoneReturnType = SomeReturnType>(
  this: Option<Value>,
  config: {
    Some: (value: Value) => SomeReturnType;
    None: () => NoneReturnType;
  },
): SomeReturnType | NoneReturnType {}
```

It will be verbose, but clearer.