### PR TITLE
Proposal: add panic channel for Future

### DIFF
--- a/src/Deferred.ts
+++ b/src/Deferred.ts
@@ -3,10 +3,12 @@ import { Future } from "./Future";
 export const Deferred = {
   make<Value>() {
     let resolve: (value: Value) => void;
-    const future = Future.make<Value>((_resolve) => {
+    let panic: (error: unknown) => void;
+    const future = Future.make<Value>((_resolve, _panic) => {
       resolve = _resolve;
+      panic = _panic;
     });
-    // @ts-expect-error `resolver` is always defined
-    return [future, resolve] as const;
+    // @ts-expect-error `resolve` and `panic` are always defined
+    return [future, resolve, panic] as const;
   },
 };

--- a/src/Future.ts
+++ b/src/Future.ts
@@ -3,14 +3,33 @@ import { Result } from "./OptionResult";
 import { LooseRecord } from "./types";
 import { zip } from "./ZipUnzip";
 
+let globalPanicListeners: Array<(error: unknown) => void> | undefined;
+
 export class __Future<A> {
   /**
    * Creates a new future from its initializer function (like `new Promise(...)`)
    */
   static make = <A>(
-    init: (resolver: (value: A) => void) => (() => void) | void,
+    init: (
+      resolver: (value: A) => void,
+      panic: (error: unknown) => void,
+    ) => (() => void) | void,
   ): Future<A> => {
     const future = Object.create(FUTURE_PROTO) as Future<A>;
+
+    const panic = (error: unknown) => {
+      if (future._state.tag === "Pending") {
+        const panicCallbacks = future._state.panicCallbacks;
+        future._state = { tag: "Panicked", error };
+        panicCallbacks?.forEach((func) => func(error));
+        globalPanicListeners?.forEach((func) => {
+          try {
+            func(error);
+          } catch (_) {}
+        });
+      }
+    };
+
     const resolver = (value: A) => {
       if (future._state.tag === "Pending") {
         const resolveCallbacks = future._state.resolveCallbacks;
@@ -18,8 +37,15 @@ export class __Future<A> {
         resolveCallbacks?.forEach((func) => func(value));
       }
     };
+
     future._state = { tag: "Pending" };
-    future._state.cancel = init(resolver);
+
+    try {
+      future._state.cancel = init(resolver, panic);
+    } catch (e) {
+      panic(e);
+    }
+
     return future as Future<A>;
   };
 
@@ -123,7 +149,7 @@ export class __Future<A> {
     array: Futures,
     { concurrency }: { concurrency: number },
   ) => {
-    return Future.make((resolve) => {
+    return Future.make((resolve, panic) => {
       const returnValue = Array(array.length);
       let index = concurrency - 1;
       let done = 0;
@@ -133,8 +159,15 @@ export class __Future<A> {
         return;
       }
 
-      const run = (func: () => Future<any>, currentIndex: number) =>
-        func().tap((value) => {
+      const run = (func: () => Future<any>, currentIndex: number) => {
+        let f: Future<any>;
+        try {
+          f = func();
+        } catch (e) {
+          panic(e);
+          return;
+        }
+        f.onResolve((value) => {
           returnValue[currentIndex] = value;
           if (++done < array.length) {
             const next = array[++index];
@@ -145,6 +178,8 @@ export class __Future<A> {
             resolve(returnValue);
           }
         });
+        f.onPanic(panic);
+      };
 
       array.slice(0, concurrency).forEach(run);
     }) as unknown as Future<{
@@ -154,16 +189,36 @@ export class __Future<A> {
     }>;
   };
 
+  /**
+   * Registers a global panic listener. Returns an unsubscribe function.
+   */
+  static onPanic = (
+    listener: (error: unknown) => void,
+  ): (() => void) => {
+    globalPanicListeners = globalPanicListeners ?? [];
+    globalPanicListeners.push(listener);
+    return () => {
+      if (globalPanicListeners) {
+        const index = globalPanicListeners.indexOf(listener);
+        if (index !== -1) {
+          globalPanicListeners.splice(index, 1);
+        }
+      }
+    };
+  };
+
   // Not accessible from the outside
   private _state:
     | {
         tag: "Pending";
         resolveCallbacks?: Array<(value: A) => void>;
+        panicCallbacks?: Array<(error: unknown) => void>;
         cancel?: void | (() => void);
         cancelCallbacks?: Array<() => void>;
       }
     | { tag: "Cancelled" }
-    | { tag: "Resolved"; value: A };
+    | { tag: "Resolved"; value: A }
+    | { tag: "Panicked"; error: unknown };
 
   protected constructor() {
     this._state = { tag: "Pending" };
@@ -178,6 +233,18 @@ export class __Future<A> {
       this._state.resolveCallbacks.push(func);
     } else if (this._state.tag === "Resolved") {
       func(this._state.value);
+    }
+  }
+
+  /**
+   * Runs the callback with the error when panicked
+   */
+  onPanic(func: (error: unknown) => void) {
+    if (this._state.tag === "Pending") {
+      this._state.panicCallbacks = this._state.panicCallbacks ?? [];
+      this._state.panicCallbacks.push(func);
+    } else if (this._state.tag === "Panicked") {
+      func(this._state.error);
     }
   }
 
@@ -215,10 +282,19 @@ export class __Future<A> {
    * (Future\<A>, A => B) => Future\<B>
    */
   map<B>(func: (value: A) => B, propagateCancel = false): Future<B> {
-    const future = Future.make<B>((resolve) => {
+    const future = Future.make<B>((resolve, panic) => {
       this.onResolve((value) => {
-        resolve(func(value));
+        let result: B;
+        try {
+          result = func(value);
+        } catch (e) {
+          panic(e);
+          return;
+        }
+        resolve(result);
       });
+
+      this.onPanic(panic);
 
       if (propagateCancel) {
         return () => {
@@ -234,8 +310,11 @@ export class __Future<A> {
     return future;
   }
 
-  then(func: (value: A) => void) {
+  then(func: (value: A) => void, onRejected?: (error: unknown) => void) {
     this.onResolve(func);
+    if (onRejected) {
+      this.onPanic(onRejected);
+    }
     return this;
   }
 
@@ -248,12 +327,21 @@ export class __Future<A> {
     func: (value: A) => Future<B>,
     propagateCancel = false,
   ): Future<B> {
-    const future = Future.make<B>((resolve) => {
+    const future = Future.make<B>((resolve, panic) => {
       this.onResolve((value) => {
-        const returnedFuture = func(value);
+        let returnedFuture: Future<B>;
+        try {
+          returnedFuture = func(value);
+        } catch (e) {
+          panic(e);
+          return;
+        }
         returnedFuture.onResolve(resolve);
+        returnedFuture.onPanic(panic);
         returnedFuture.onCancel(() => future.cancel());
       });
+
+      this.onPanic(panic);
 
       if (propagateCancel) {
         return () => {
@@ -270,49 +358,62 @@ export class __Future<A> {
   }
 
   /**
-   * Runs the callback and returns `this`
+   * Runs the callback and returns a new future that resolves to the same value
    */
   tap(this: Future<A>, func: (value: A) => unknown): Future<A> {
-    this.onResolve(func);
-    return this;
+    const future = Future.make<A>((resolve, panic) => {
+      this.onResolve((value) => {
+        try {
+          func(value);
+        } catch (e) {
+          panic(e);
+          return;
+        }
+        resolve(value);
+      });
+
+      this.onPanic(panic);
+    });
+
+    this.onCancel(() => {
+      future.cancel();
+    });
+
+    return future;
   }
 
   /**
    * For Future<Result<*>>:
    *
-   * Runs the callback with the value if ok and returns `this`
+   * Runs the callback with the value if ok and returns a new future
    */
   tapOk<A, E>(
     this: Future<Result<A, E>>,
     func: (value: A) => unknown,
   ): Future<Result<A, E>> {
-    this.onResolve((value) => {
+    return this.tap((value) => {
       value.match({
-        Ok: (value) => func(value),
+        Ok: (v) => func(v),
         Error: () => {},
       });
     });
-
-    return this;
   }
 
   /**
    * For Future<Result<*>>:
    *
-   * Runs the callback with the error if in error and returns `this`
+   * Runs the callback with the error if in error and returns a new future
    */
   tapError<A, E>(
     this: Future<Result<A, E>>,
     func: (value: E) => unknown,
   ): Future<Result<A, E>> {
-    this.onResolve((value) => {
+    return this.tap((value) => {
       value.match({
         Ok: () => {},
-        Error: (error) => func(error),
+        Error: (e) => func(e),
       });
     });
-
-    return this;
   }
 
   /**
@@ -424,11 +525,83 @@ export class __Future<A> {
   }
 
   /**
+   * Runs the side-effect callback when panicked, then re-panics with the original error
+   */
+  tapPanic(func: (error: unknown) => void): Future<A> {
+    const future = Future.make<A>((resolve, panic) => {
+      this.onResolve(resolve);
+      this.onPanic((error) => {
+        try {
+          func(error);
+        } catch (e) {
+          panic(e);
+          return;
+        }
+        panic(error);
+      });
+    });
+
+    this.onCancel(() => {
+      future.cancel();
+    });
+
+    return future;
+  }
+
+  /**
+   * Catches a panic and recovers with a value or Future
+   */
+  catchPanic(handler: (error: unknown) => A | Future<A>): Future<A> {
+    const future = Future.make<A>((resolve, panic) => {
+      this.onResolve(resolve);
+      this.onPanic((error) => {
+        let result: A | Future<A>;
+        try {
+          result = handler(error);
+        } catch (e) {
+          panic(e);
+          return;
+        }
+        if (Future.isFuture(result)) {
+          (result as Future<A>).onResolve(resolve);
+          (result as Future<A>).onPanic(panic);
+          (result as Future<A>).onCancel(() => future.cancel());
+        } else {
+          resolve(result as A);
+        }
+      });
+    });
+
+    this.onCancel(() => {
+      future.cancel();
+    });
+
+    return future;
+  }
+
+  /**
+   * Converts panics to Result.Error and resolved values to Result.Ok
+   */
+  panicToResult(): Future<Result<A, unknown>> {
+    const future = Future.make<Result<A, unknown>>((resolve) => {
+      this.onResolve((value) => resolve(Result.Ok(value)));
+      this.onPanic((error) => resolve(Result.Error(error)));
+    });
+
+    this.onCancel(() => {
+      future.cancel();
+    });
+
+    return future;
+  }
+
+  /**
    * Converts the future into a promise
    */
   toPromise(): Promise<A> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       this.onResolve(resolve);
+      this.onPanic(reject);
     });
   }
 
@@ -445,6 +618,7 @@ export class __Future<A> {
           Error: reject,
         });
       });
+      this.onPanic(reject);
     });
   }
 }

--- a/test/Future.test.ts
+++ b/test/Future.test.ts
@@ -1,10 +1,24 @@
-import { expect, test } from "vitest";
+import { expect, test, afterEach } from "vitest";
 import { Future } from "../src/Future";
+import { Deferred } from "../src/Deferred";
 import { Result } from "../src/OptionResult";
 
 const isCancelled = <A>(future: Future<A>) =>
   // @ts-expect-error - Access to a protected property
   future._state.tag === "Cancelled";
+
+const isPanicked = <A>(future: Future<A>) =>
+  // @ts-expect-error - Access to a protected property
+  future._state.tag === "Panicked";
+
+const getPanicError = <A>(future: Future<A>) => {
+  // @ts-expect-error - Access to a protected property
+  if (future._state.tag === "Panicked") {
+    // @ts-expect-error - Access to a protected property
+    return future._state.error;
+  }
+  throw new Error("Future is not panicked");
+};
 
 test("Future make value", async () => {
   const value = await Future.value(1);
@@ -537,4 +551,425 @@ test("Future try on last", async () => {
 
   expect(attempts).toBe(4);
   expect(value).toEqual(Result.Error(1));
+});
+
+// --- Panic channel tests ---
+
+test("map callback throw panics the derived future (sync source)", () => {
+  const error = new Error("boom");
+  const future = Future.value(1).map(() => {
+    throw error;
+  });
+  expect(isPanicked(future)).toBe(true);
+  expect(getPanicError(future)).toBe(error);
+});
+
+test("map callback throw panics the derived future (async source)", async () => {
+  const error = new Error("boom");
+  const [source, resolve] = Deferred.make<number>();
+  const derived = source.map(() => {
+    throw error;
+  });
+
+  expect(isPanicked(derived)).toBe(false);
+  resolve(1);
+  expect(isPanicked(derived)).toBe(true);
+  expect(getPanicError(derived)).toBe(error);
+});
+
+test("mapOk callback throw panics the derived future", () => {
+  const error = new Error("boom");
+  const future = Future.value(Result.Ok(1)).mapOk(() => {
+    throw error;
+  });
+  expect(isPanicked(future)).toBe(true);
+  expect(getPanicError(future)).toBe(error);
+});
+
+test("flatMap callback throw panics the derived future", () => {
+  const error = new Error("boom");
+  const future = Future.value(1).flatMap(() => {
+    throw error;
+  });
+  expect(isPanicked(future)).toBe(true);
+  expect(getPanicError(future)).toBe(error);
+});
+
+test("tap callback throw panics the derived future", () => {
+  const error = new Error("boom");
+  const future = Future.value(1).tap(() => {
+    throw error;
+  });
+  expect(isPanicked(future)).toBe(true);
+  expect(getPanicError(future)).toBe(error);
+});
+
+test("tapOk callback throw panics the derived future", () => {
+  const error = new Error("boom");
+  const future = Future.value(Result.Ok(1)).tapOk(() => {
+    throw error;
+  });
+  expect(isPanicked(future)).toBe(true);
+  expect(getPanicError(future)).toBe(error);
+});
+
+test("flatMap returning panicked future panics derived", () => {
+  const error = new Error("inner panic");
+  const panicked = Future.make<number>((_resolve, panic) => {
+    panic(error);
+  });
+  const derived = Future.value(1).flatMap(() => panicked);
+  expect(isPanicked(derived)).toBe(true);
+  expect(getPanicError(derived)).toBe(error);
+});
+
+test("chain of 3+ combinators: source panic propagates to all", () => {
+  const error = new Error("source panic");
+  const [source, , panic] = Deferred.make<number>();
+
+  const d1 = source.map((x) => x + 1);
+  const d2 = d1.map((x) => x + 2);
+  const d3 = d2.map((x) => x + 3);
+
+  panic(error);
+
+  expect(isPanicked(d1)).toBe(true);
+  expect(isPanicked(d2)).toBe(true);
+  expect(isPanicked(d3)).toBe(true);
+  expect(getPanicError(d3)).toBe(error);
+});
+
+test("parent panic propagates without executing child callback", () => {
+  const [source, , panic] = Deferred.make<number>();
+  let called = false;
+  const derived = source.map(() => {
+    called = true;
+    return 42;
+  });
+
+  panic(new Error("parent panic"));
+
+  expect(called).toBe(false);
+  expect(isPanicked(derived)).toBe(true);
+});
+
+test("flatMap: inner future panics propagates to outer", async () => {
+  const error = new Error("inner");
+  const inner = Future.make<number>((_resolve, panic) => {
+    setTimeout(() => panic(error), 10);
+  });
+  const outer = Future.value(1).flatMap(() => inner);
+
+  await new Promise((r) => setTimeout(r, 50));
+  expect(isPanicked(outer)).toBe(true);
+  expect(getPanicError(outer)).toBe(error);
+});
+
+test("catchPanic recovers panic with fallback value", () => {
+  const future = Future.make<number>((_resolve, panic) => {
+    panic(new Error("boom"));
+  });
+
+  let resolved: number | undefined;
+  future.catchPanic(() => 42).onResolve((v) => {
+    resolved = v;
+  });
+
+  expect(resolved).toBe(42);
+});
+
+test("catchPanic returning Future resolves", async () => {
+  const future = Future.make<number>((_resolve, panic) => {
+    panic(new Error("boom"));
+  });
+
+  const recovered = await future.catchPanic(() => Future.value(99));
+  expect(recovered).toBe(99);
+});
+
+test("catchPanic returning panicked Future re-panics", () => {
+  const error1 = new Error("first");
+  const error2 = new Error("second");
+  const future = Future.make<number>((_resolve, panic) => {
+    panic(error1);
+  });
+
+  const recovered = future.catchPanic(() =>
+    Future.make<number>((_r, p) => p(error2)),
+  );
+  expect(isPanicked(recovered)).toBe(true);
+  expect(getPanicError(recovered)).toBe(error2);
+});
+
+test("catchPanic handler throws re-panics with handler error", () => {
+  const handlerError = new Error("handler threw");
+  const future = Future.make<number>((_resolve, panic) => {
+    panic(new Error("original"));
+  });
+
+  const recovered = future.catchPanic(() => {
+    throw handlerError;
+  });
+  expect(isPanicked(recovered)).toBe(true);
+  expect(getPanicError(recovered)).toBe(handlerError);
+});
+
+test("tapPanic side-effect called with panic value", () => {
+  const error = new Error("boom");
+  let captured: unknown;
+  const future = Future.make<number>((_resolve, panic) => {
+    panic(error);
+  });
+
+  const tapped = future.tapPanic((e) => {
+    captured = e;
+  });
+
+  expect(captured).toBe(error);
+  expect(isPanicked(tapped)).toBe(true);
+  expect(getPanicError(tapped)).toBe(error);
+});
+
+test("tapPanic throw re-panics with new error", () => {
+  const newError = new Error("tap threw");
+  const future = Future.make<number>((_resolve, panic) => {
+    panic(new Error("original"));
+  });
+
+  const tapped = future.tapPanic(() => {
+    throw newError;
+  });
+  expect(isPanicked(tapped)).toBe(true);
+  expect(getPanicError(tapped)).toBe(newError);
+});
+
+test("tapPanic on resolved future is a no-op", async () => {
+  let called = false;
+  const result = await Future.value(42).tapPanic(() => {
+    called = true;
+  });
+  expect(called).toBe(false);
+  expect(result).toBe(42);
+});
+
+test("panicToResult: resolved becomes Result.Ok", async () => {
+  const result = await Future.value(42).panicToResult();
+  expect(result).toEqual(Result.Ok(42));
+});
+
+test("panicToResult: panicked becomes Result.Error", async () => {
+  const error = new Error("boom");
+  const result = await Future.make<number>((_resolve, panic) => {
+    panic(error);
+  }).panicToResult();
+  expect(result).toEqual(Result.Error(error));
+});
+
+test("toPromise rejects on panic", async () => {
+  const error = new Error("boom");
+  const future = Future.make<number>((_resolve, panic) => {
+    panic(error);
+  });
+
+  try {
+    await future.toPromise();
+    expect(false).toBe(true);
+  } catch (err) {
+    expect(err).toBe(error);
+  }
+});
+
+test("resultToPromise rejects on panic", async () => {
+  const error = new Error("boom");
+  const future = Future.make<Result<number, string>>((_resolve, panic) => {
+    panic(error);
+  });
+
+  try {
+    await future.resultToPromise();
+    expect(false).toBe(true);
+  } catch (err) {
+    expect(err).toBe(error);
+  }
+});
+
+test("await panicked future throws", async () => {
+  const error = new Error("boom");
+  const future = Future.make<number>((_resolve, panic) => {
+    panic(error);
+  });
+
+  try {
+    await future;
+    expect(false).toBe(true);
+  } catch (err) {
+    expect(err).toBe(error);
+  }
+});
+
+test("fromPromise(...).mapOk(throws) settles as panic", async () => {
+  const error = new Error("mapOk boom");
+  const future = Future.fromPromise(Promise.resolve(1)).mapOk(() => {
+    throw error;
+  });
+
+  await new Promise((r) => setTimeout(r, 10));
+  expect(isPanicked(future)).toBe(true);
+  expect(getPanicError(future)).toBe(error);
+});
+
+test("Future.onPanic listener called on panic", () => {
+  let captured: unknown;
+  const unsubscribe = Future.onPanic((e) => {
+    captured = e;
+  });
+
+  const error = new Error("global");
+  Future.make<number>((_resolve, panic) => {
+    panic(error);
+  });
+
+  expect(captured).toBe(error);
+  unsubscribe();
+});
+
+test("Future.onPanic unsubscribe works", () => {
+  let callCount = 0;
+  const unsubscribe = Future.onPanic(() => {
+    callCount++;
+  });
+
+  Future.make<number>((_resolve, panic) => {
+    panic(new Error("first"));
+  });
+  expect(callCount).toBe(1);
+
+  unsubscribe();
+
+  Future.make<number>((_resolve, panic) => {
+    panic(new Error("second"));
+  });
+  expect(callCount).toBe(1);
+});
+
+test("Future.onPanic listener throw does not crash", () => {
+  const unsubscribe = Future.onPanic(() => {
+    throw new Error("listener crash");
+  });
+
+  expect(() => {
+    Future.make<number>((_resolve, panic) => {
+      panic(new Error("trigger"));
+    });
+  }).not.toThrow();
+
+  unsubscribe();
+});
+
+test("init throws panics the future", () => {
+  const error = new Error("init boom");
+  const future = Future.make<number>(() => {
+    throw error;
+  });
+  expect(isPanicked(future)).toBe(true);
+  expect(getPanicError(future)).toBe(error);
+});
+
+test("init calls panic explicitly", () => {
+  const error = new Error("explicit panic");
+  const future = Future.make<number>((_resolve, panic) => {
+    panic(error);
+  });
+  expect(isPanicked(future)).toBe(true);
+  expect(getPanicError(future)).toBe(error);
+});
+
+test("resolve then panic stays resolved", () => {
+  let panicFn: (error: unknown) => void;
+  const future = Future.make<number>((resolve, panic) => {
+    resolve(42);
+    panicFn = panic;
+  });
+  panicFn!(new Error("late panic"));
+
+  let resolved: number | undefined;
+  future.onResolve((v) => {
+    resolved = v;
+  });
+  expect(resolved).toBe(42);
+  expect(isPanicked(future)).toBe(false);
+});
+
+test("panic then resolve stays panicked", () => {
+  let resolveFn: (value: number) => void;
+  const future = Future.make<number>((resolve, panic) => {
+    panic(new Error("first"));
+    resolveFn = resolve;
+  });
+  resolveFn!(42);
+
+  expect(isPanicked(future)).toBe(true);
+  let resolved = false;
+  future.onResolve(() => {
+    resolved = true;
+  });
+  expect(resolved).toBe(false);
+});
+
+test("callbacks called at most once on panic", () => {
+  let count = 0;
+  const future = Future.make<number>((_resolve, panic) => {
+    panic(new Error("first"));
+    panic(new Error("second"));
+  });
+
+  future.onPanic(() => {
+    count++;
+  });
+
+  expect(count).toBe(1);
+});
+
+test("Deferred.make exposes panic as third element", () => {
+  const [future, resolve, panic] = Deferred.make<number>();
+  expect(typeof resolve).toBe("function");
+  expect(typeof panic).toBe("function");
+
+  panic(new Error("deferred panic"));
+  expect(isPanicked(future)).toBe(true);
+});
+
+test("concurrent propagates panic from individual future", async () => {
+  const error = new Error("concurrent panic");
+  const future = Future.concurrent(
+    [
+      () => Future.value(1),
+      () =>
+        Future.make<number>((_resolve, panic) => {
+          panic(error);
+        }),
+      () => Future.value(3),
+    ],
+    { concurrency: 3 },
+  );
+
+  expect(isPanicked(future)).toBe(true);
+  expect(getPanicError(future)).toBe(error);
+});
+
+test("concurrent propagates panic from throwing factory", () => {
+  const error = new Error("factory throw");
+  const future = Future.concurrent(
+    [
+      () => Future.value(1),
+      () => {
+        throw error;
+      },
+      () => Future.value(3),
+    ],
+    { concurrency: 3 },
+  );
+
+  expect(isPanicked(future)).toBe(true);
+  expect(getPanicError(future)).toBe(error);
 });


### PR DESCRIPTION
Introduce a third terminal state (Panicked) that catches exceptions thrown in user callbacks (map, flatMap, tap, etc.) instead of leaving derived futures pending forever or surfacing unhandled exceptions.

- Add Panicked state + onPanic subscription method
- Wrap user callbacks in try/catch in map, flatMap, tap
- Propagate panics from parent to child futures
- Add tapPanic, catchPanic, panicToResult instance methods
- Add Future.onPanic global listener hook
- Update then/toPromise/resultToPromise for panic rejection
- Update concurrent for panic propagation
- Expose panic in Deferred.make as third tuple element
- Add 34 comprehensive panic tests