### PR TITLE
[Docs] fix Future.concurrent signature

### DIFF
--- a/docs/docs/future.md
+++ b/docs/docs/future.md
@@ -158,7 +158,7 @@ Future.all([Future.value(1), Future.value(2), Future.value(3)])
 ### Future.concurrent(futureGetters, options)
 
 ```ts
-all(futures: Array<() => Future<A>>, {concurrency: number}): Future<Array<A>>
+concurrent(futures: Array<() => Future<A>>, {concurrency: number}): Future<Array<A>>
 ```
 
 Like `Future.all` with a max concurrency, and in order to control the flow, provided with functions returning futures.


### PR DESCRIPTION
Hello @bloodyowl 

I was reading the documentation of `Future` and it seems there is a copy paste error in `Future.concurrent` signature. Feel free to edit or close this PR if I'm wrong. (by the way this is really nice to have this feature)